### PR TITLE
feat(examples/individual_rules/import_rules): add initial examples

### DIFF
--- a/examples/individual_rules/import_rules.py
+++ b/examples/individual_rules/import_rules.py
@@ -5,3 +5,34 @@
 # This example file contains pieces of code that either comply with or violate the
 # import rules `no-wildcard-imports` and `no-relative-imports`, as well as the
 # rules for standardized import aliases `use-standard-name-for-aliases-*`.
+
+# no violation
+import time
+
+# violates `no-wildcard-imports`
+from time import *
+
+# also violates `no-wildcard-imports`
+from rich.table import *
+
+# violate `no-relative-imports`
+from . import important_function
+from .my_module import important_function
+from ..my_module import important_function, unimportant_function
+
+# no violation - this is an absolute member import
+from my_company.my_module import important_function
+
+# violates both `no-wildcard-imports` and `no-relative-imports`
+from .something import *
+
+# no violation: import common libraries with their "standard" aliases
+import numpy as np
+import pandas as pd
+import tensorflow as tf
+
+# violate `use-standard-name-for-aliases-*` rules
+# warning: chaos ahead!
+import numpy as pd
+import pandas as tf
+import tensorflow as np


### PR DESCRIPTION
## Overview

Add initial examples for individual violations to the import rules.

Note that:

* This PR is intended to put **`examples/individual_rules/import_rules.py`** in its final form already, so please let me know if you would like to have anything changed in it;
* The accepted form of this PR will also be used as a basis for the other individual rules.

## Comment about comments

Please make sure that you agree with the number and the size of comments around each line of code. Would you prefer fewer comments? More comments?

Take the first example for no violations:
```python
# no violation
import time
```
It could be simplified as
```python
import time
```
or enhanced as
```python
# --------------------------------------------------------
# module import: no violation example
# --------------------------------------------------------
# The following line of code does not violate 
# any import rules
import time
```

The version without comments feels too dry and uninformative (people reading that line of code may think "why is this line here?"), whereas the more commented version looks too verbose to me. That is why I decided to go for just short, descriptive comments for now.

## Question about the example code

Also, do you think that we need more code to showcase the rules? We could give one example for each of the `use-standard-name-for-aliases-*` rules - however, I think that that would be too much code to read and understand without bringing any extra value.