### PR TITLE
docs: add links to Google license

### DIFF
--- a/.sourcery.yaml
+++ b/.sourcery.yaml
@@ -33,6 +33,10 @@ rules:
 # 
 # The following rules instruct Sourcery to help making sure that the Google Python Style
 # Guide is respected in this project.
+# 
+# The [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) was 
+# created by [Google](https://github.com/google) and published under the 
+# [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/legalcode) license.
 
 # ----------------------------------------------------------------------------------
 # [2.2 Import Rules](https://docs.sourcery.ai/Reference/Custom-Rules/gpsg/#22-import-rules)

--- a/README.md
+++ b/README.md
@@ -172,3 +172,7 @@ Make sure you have [pre-commit installed](https://pre-commit.com/#install) toget
 <!-- TODO: ### GitHub Action -->
 
 <!-- TODO: ## Use this in your project -->
+
+## Licensing
+
+This repository contains an implementation of the [Google Python Style Guide](https://google.github.io/styleguide/pyguide.html) as [Sourcery](https://sourcery.ai/) rules. The style guide itself was created by [Google](https://github.com/google) and published under the [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/legalcode) license.


### PR DESCRIPTION
According to [CC BY 3.0](https://creativecommons.org/licenses/by/3.0/), the license under which Google published their Python style guide, it seems to be sufficient to give proper attribution to the creator (that is, Google) and add a link to the license.

I included both the attribution and the link in the README and in the `.sourcery.yaml` config file.

Please review this PR carefully. This is the first time I am dealing with licensing, and I know how important it is.

**Question to the reviewers**: should we include a top-level license so that people know that they are free to copy-paste-tweak the Sourcery rules?